### PR TITLE
Allow for CUDA 2.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 [compat]
 AmplNLReader = ">= 0.8"
 BinaryProvider = "~0.5"
-CUDA = "~1.3"
+CUDA = ">=1.3"
 IterativeSolvers = "~0.8"
 JuMP = "~0.21"
 LightGraphs = "~1.3"


### PR DESCRIPTION
ProxAL/ExaPF require CUDA.jl 2.x which breaks the dependencies since MadNLP does not allow CUDA.jl 2.x. This should fix that.