### PR TITLE
user can give shared library path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ julia> ENV["MADNLP_ENALBE_OPENMP"] = false          # default is "true"
 julia> ENV["MADNLP_OPTIMIZATION_FLAG"] = "-O2"      # default is "-O3"
 ```
 
+Alternatively, if the user has already installed HSL/pardiso library, one can simply specify the library path as follows:
+```julia
+julia> ENV["MADNLP_HSL_LIBRARY_PATH"] = "/opt/lib/libcoinhsl.so"
+julia> ENV["MADNLP_PARDISO_LIBRARY_PATH"] = "/opt/lib/libpardiso.so" 
+```
+In this case, the source code is not compiled and the provided shared library is directly used.
+
 ## Usage
 MadNLP is interfaced with modeling packages: 
 - [JuMP](https://github.com/jump-dev/JuMP.jl)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -16,6 +16,8 @@ const rpath = `-Wl,-rpath,`
 const whole_archive= Sys.isapple() ? `-Wl,-all_load` : `-Wl,--whole-archive`
 const no_whole_archive = Sys.isapple() ? `-Wl,-noall_load` : `-Wl,--no-whole-archive`
 const libdir     = mkpath(joinpath(@__DIR__, "lib"))
+const hsl_shared_library = haskey(ENV,"MADNLP_HSL_LIBRARY_PATH") ? ENV["MADNLP_HSL_LIBRARY_PATH"] : ""
+const pardiso_shared_library = haskey(ENV,"MADNLP_PARDISO_LIBRARY_PATH") ? ENV["MADNLP_PARDISO_LIBRARY_PATH"] : ""
 const CC = haskey(ENV,"MADNLP_CC") ? ENV["MADNLP_CC"] : `gcc`
 const FC = haskey(ENV,"MADNLP_FC") ? ENV["MADNLP_FC"] : `gfortran`
 const libmetis_dir = joinpath(artifact"METIS", "lib")
@@ -39,48 +41,58 @@ isvalid(cmd::Cmd)=(try run(cmd) catch e return false end; return true)
 @info "Building MadNLP with $(blasvendor == :mkl ? "MKL" : "OpenBLAS")"
 
 # HSL
-if isvalid(`$FC --version`)
-    const hsl_version = "2015.06.23"
-    const hsl_archive = joinpath(@__DIR__,"download","coinhsl-$hsl_version.tar.gz")
-    push!(products,FileProduct(prefix,joinpath(libdir,"libhsl.$so"), :libhsl))
-    if isfile(hsl_archive)
-        unpack(hsl_archive,joinpath(@__DIR__, "download"))
-        OC = OutputCollector[]
-        cd("download/coinhsl-$hsl_version")
-        push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o common/deps.o common/deps.f`,verbose=verbose))
-        push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o common/deps90.o common/deps90.f90`,verbose=verbose))
-        wait.(OC); empty!(OC)
-        push!(OC,OutputCollector(`$FC -fPIC -c $optimization_flag -o mc19/mc19d.o mc19/mc19d.f`,verbose=verbose))
-        push!(OC,OutputCollector(`$FC -fPIC -c $optimization_flag -o ma27/ma27d.o ma27/ma27d.f`,verbose=verbose))
-        push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o ma57/ma57d.o ma57/ma57d.f`,verbose=verbose))    
-        wait.(OC); empty!(OC)
-        push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_ma77/hsl_ma77d.o hsl_ma77/hsl_ma77d.f90`,verbose=verbose))
-        push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_ma86/hsl_ma86d.o hsl_ma86/hsl_ma86d.f90`,verbose=verbose))
-        push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_ma97/hsl_ma97d.o hsl_ma97/hsl_ma97d.f90`,verbose=verbose))
-        wait.(OC); empty!(OC)
-        push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_ma77/C/hsl_ma77d_ciface.o hsl_ma77/C/hsl_ma77d_ciface.f90`,verbose=verbose))
-        push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_ma86/C/hsl_ma86d_ciface.o hsl_ma86/C/hsl_ma86d_ciface.f90`,verbose=verbose))
-        push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_mc68/C/hsl_mc68i_ciface.o hsl_mc68/C/hsl_mc68i_ciface.f90`,verbose=verbose))
-        push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_ma97/C/hsl_ma97d_ciface.o hsl_ma97/C/hsl_ma97d_ciface.f90`,verbose=verbose))
-        wait.(OC); empty!(OC)
-        wait(OutputCollector(`$FC -o$(libdir)/libhsl.$so -shared -fPIC $optimization_flag common/deps90.o common/deps.o mc19/mc19d.o ma27/ma27d.o ma57/ma57d.o hsl_ma77/hsl_ma77d.o hsl_ma77/C/hsl_ma77d_ciface.o hsl_ma86/hsl_ma86d.o hsl_ma86/C/hsl_ma86d_ciface.o hsl_mc68/C/hsl_mc68i_ciface.o hsl_ma97/hsl_ma97d.o hsl_ma97/C/hsl_ma97d_ciface.o $openmp_flag $with_metis $(blasvendor == :mkl ? with_mkl : with_openblas)`,verbose=verbose))
-        cd("$(@__DIR__)")
+if hsl_shared_library == ""
+    if isvalid(`$FC --version`)
+        const hsl_version = "2015.06.23"
+        const hsl_archive = joinpath(@__DIR__,"download","coinhsl-$hsl_version.tar.gz")
+        push!(products,FileProduct(prefix,joinpath(libdir,"libhsl.$so"), :libhsl))
+        if isfile(hsl_archive)
+            unpack(hsl_archive,joinpath(@__DIR__, "download"))
+            OC = OutputCollector[]
+            cd("download/coinhsl-$hsl_version")
+            push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o common/deps.o common/deps.f`,verbose=verbose))
+            push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o common/deps90.o common/deps90.f90`,verbose=verbose))
+            wait.(OC); empty!(OC)
+            push!(OC,OutputCollector(`$FC -fPIC -c $optimization_flag -o mc19/mc19d.o mc19/mc19d.f`,verbose=verbose))
+            push!(OC,OutputCollector(`$FC -fPIC -c $optimization_flag -o ma27/ma27d.o ma27/ma27d.f`,verbose=verbose))
+            push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o ma57/ma57d.o ma57/ma57d.f`,verbose=verbose))    
+            wait.(OC); empty!(OC)
+            push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_ma77/hsl_ma77d.o hsl_ma77/hsl_ma77d.f90`,verbose=verbose))
+            push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_ma86/hsl_ma86d.o hsl_ma86/hsl_ma86d.f90`,verbose=verbose))
+            push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_ma97/hsl_ma97d.o hsl_ma97/hsl_ma97d.f90`,verbose=verbose))
+            wait.(OC); empty!(OC)
+            push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_ma77/C/hsl_ma77d_ciface.o hsl_ma77/C/hsl_ma77d_ciface.f90`,verbose=verbose))
+            push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_ma86/C/hsl_ma86d_ciface.o hsl_ma86/C/hsl_ma86d_ciface.f90`,verbose=verbose))
+            push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_mc68/C/hsl_mc68i_ciface.o hsl_mc68/C/hsl_mc68i_ciface.f90`,verbose=verbose))
+            push!(OC,OutputCollector(`$FC $openmp_flag -fPIC -c $optimization_flag -o hsl_ma97/C/hsl_ma97d_ciface.o hsl_ma97/C/hsl_ma97d_ciface.f90`,verbose=verbose))
+            wait.(OC); empty!(OC)
+            wait(OutputCollector(`$FC -o$(libdir)/libhsl.$so -shared -fPIC $optimization_flag common/deps90.o common/deps.o mc19/mc19d.o ma27/ma27d.o ma57/ma57d.o hsl_ma77/hsl_ma77d.o hsl_ma77/C/hsl_ma77d_ciface.o hsl_ma86/hsl_ma86d.o hsl_ma86/C/hsl_ma86d_ciface.o hsl_mc68/C/hsl_mc68i_ciface.o hsl_ma97/hsl_ma97d.o hsl_ma97/C/hsl_ma97d_ciface.o $openmp_flag $with_metis $(blasvendor == :mkl ? with_mkl : with_openblas)`,verbose=verbose))
+            cd("$(@__DIR__)")
+        end
+        @info "Building HSL (Ma27, Ma57, Ma77, Ma86, Ma97) $(build_succeded(products[end]))."
     end
+else 
+    push!(products,FileProduct(hsl_shared_library, :libhsl))
     @info "Building HSL (Ma27, Ma57, Ma77, Ma86, Ma97) $(build_succeded(products[end]))."
 end
 
 # Pardiso
-if isvalid(`$CC --version`)
-    const libpardiso_dir = joinpath(@__DIR__,"download")
-    push!(products,FileProduct(prefix,joinpath(libdir,"libpardiso.$so"),:libpardiso))
-    for name in readdir(libpardiso_dir)[occursin.("libpardiso",readdir(libpardiso_dir))]
-        startswith(name,"lib") && endswith(name,so) ? name = splitext(name)[1][4:end] : continue
-        with_pardiso=`-L$libpardiso_dir $rpath$libpardiso_dir -l$name`
-        wait(OutputCollector(`$CC -shared -olib/libpardiso.$so .pardiso_dummy.c $whole_archive $with_pardiso $no_whole_archive $with_openblas -lgfortran $openmp_flag -lpthread -lm`,verbose=verbose))
-        Sys.isapple() && satisfied(products[end]) &&
-            wait(OutputCollector(`install_name_tool -change lib$name.$so @rpath/lib$name.$so lib/libpardiso.$so`,verbose=verbose))
-        satisfied(products[end]) && break
+if pardiso_shared_library == ""
+    if isvalid(`$CC --version`)
+        const libpardiso_dir = joinpath(@__DIR__,"download")
+        push!(products,FileProduct(prefix,joinpath(libdir,"libpardiso.$so"),:libpardiso))
+        for name in readdir(libpardiso_dir)[occursin.("libpardiso",readdir(libpardiso_dir))]
+            startswith(name,"lib") && endswith(name,so) ? name = splitext(name)[1][4:end] : continue
+            with_pardiso=`-L$libpardiso_dir $rpath$libpardiso_dir -l$name`
+            wait(OutputCollector(`$CC -shared -olib/libpardiso.$so .pardiso_dummy.c $whole_archive $with_pardiso $no_whole_archive $with_openblas -lgfortran $openmp_flag -lpthread -lm`,verbose=verbose))
+            Sys.isapple() && satisfied(products[end]) &&
+                wait(OutputCollector(`install_name_tool -change lib$name.$so @rpath/lib$name.$so lib/libpardiso.$so`,verbose=verbose))
+            satisfied(products[end]) && break
+        end
+        @info "Building Pardiso $(build_succeded(products[end]))."
     end
+else
+    push!(products,FileProduct(pardiso_shared_library, :libpardiso))
     @info "Building Pardiso $(build_succeded(products[end]))."
 end
 

--- a/src/MadNLP.jl
+++ b/src/MadNLP.jl
@@ -51,8 +51,16 @@ include(joinpath("Interfaces","interfaces.jl"))
 # Initialize
 function __init__()
     check_deps()
-    @isdefined(libhsl) && dlopen(libhsl,RTLD_DEEPBIND)
-    @isdefined(libpardiso) && dlopen(libpardiso,RTLD_DEEPBIND)
+    try 
+        @isdefined(libhsl) && dlopen(libhsl,RTLD_DEEPBIND)
+    catch e
+        println("HSL shared library cannot be loaded")
+    end
+    try
+        @isdefined(libpardiso) && dlopen(libpardiso,RTLD_DEEPBIND)
+    catch e
+        println("Pardiso shared library cannot be loaded")
+    end
     set_blas_num_threads(Threads.nthreads(); permanent=true)
 end
 


### PR DESCRIPTION
This change allows the user to provide the libhsl shared library directly (e.g., the one used by Ipopt) rather than HSL source code.