### PR TITLE
Add support for cuSOLVER's sytrs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.5']
+        julia-version: ['1.6']
         julia-arch: [x64]
         os: [ubuntu-latest,macos-latest,windows-latest]
 
@@ -27,7 +27,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        julia-version: ['1.5']
+        julia-version: ['1.6']
         julia-arch: [x64]
         os: [ubuntu-latest]
     steps:
@@ -42,7 +42,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1.5']
+        julia-version: ['1.6']
         julia-arch: [x64]
         os: [ubuntu-latest]
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         julia-version: ['1.6']
         julia-arch: [x64]
-        os: [ubuntu-latest,macos-latest,windows-latest]
+        os: [ubuntu-latest,macos-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 [compat]
 AmplNLReader = "~0.9"
 BinaryProvider = "~0.5"
-CUDA = "~1.3, ~2, 3.0"
+CUDA = "~3.3"
 IterativeSolvers = "~0.9.1"
 JuMP = "~0.21"
 LightGraphs = "~1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -44,7 +44,7 @@ OpenBLAS32_jll = "~0.3"
 Plasmo = "~0.3"
 SolverCore = "~0.1"
 StaticArrays = "~0.12, 1.0"
-julia = "1.5"
+julia = "1.6"
 
 [extras]
 AmplNLReader = "77dd3d4c-cb1d-5e09-9340-85030ff7ba66"

--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 [compat]
 AmplNLReader = "~0.9"
 BinaryProvider = "~0.5"
-CUDA = "~3.3"
+CUDA = "~3"
 IterativeSolvers = "~0.9.1"
 JuMP = "~0.21"
 LightGraphs = "~1.3"

--- a/src/LinearSolvers/lapackgpu.jl
+++ b/src/LinearSolvers/lapackgpu.jl
@@ -125,7 +125,7 @@ if toolkit_version() >= v"11.3.1"
     end
 else
     is_inertia(M::Solver) = M.opt.lapackgpu_algorithm == BUNCHKAUFMAN
-    inertia(M::Solver) = LapackCPU.inertia(M.etc[:fact_cpu],M.etc[:ipiv_cpu],M.info[])
+    inertia(M::Solver) = LapackCPU.inertia(M.etc[:fact_cpu],M.etc[:ipiv_cpu],M.etc[:info_cpu][])
 
     function factorize_bunchkaufman!(M::Solver)
         haskey(M.etc,:ipiv) || (M.etc[:ipiv] = CuVector{Int32}(undef,size(M.dense,1)))
@@ -141,9 +141,11 @@ else
 
         # need to send the factorization back to cpu to call mkl sytrs --------------
         haskey(M.etc,:fact_cpu) || (M.etc[:fact_cpu] = Matrix{Float64}(undef,size(M.dense)))
-        haskey(M.etc,:ipiv_cpu) || (M.etc[:ipiv_cpu] = Vector{Int}(undef,size(M.dense,1)))
+        haskey(M.etc,:ipiv_cpu) || (M.etc[:ipiv_cpu] = Vector{Int}(undef,length(M.etc[:ipiv])))
+        haskey(M.etc,:info_cpu) || (M.etc[:info_cpu] = Vector{Int}(undef,length(M.info)))
         copyto!(M.etc[:fact_cpu],M.fact)
         copyto!(M.etc[:ipiv_cpu],M.etc[:ipiv])
+        copyto!(M.etc[:info_cpu],M.info)
         # ---------------------------------------------------------------------------
         return M
     end

--- a/src/MadNLP.jl
+++ b/src/MadNLP.jl
@@ -23,7 +23,7 @@ import JuMP: _create_nlp_block_data, set_optimizer, GenericAffExpr, backend, ter
 import NLPModels: finalize, AbstractNLPModel, obj, grad!, cons!, jac_coord!, hess_coord!, hess_structure!, jac_structure!
 import SolverCore: GenericExecutionStats
 import MUMPS_seq_jll
-import CUDA: CUBLAS, CUSOLVER, CuVector, CuMatrix, has_cuda_gpu, R_64F
+import CUDA: CUBLAS, CUSOLVER, CuVector, CuMatrix, has_cuda_gpu, toolkit_version, R_64F
 
 const MOI = MathOptInterface
 const MOIU = MathOptInterface.Utilities

--- a/src/MadNLP.jl
+++ b/src/MadNLP.jl
@@ -23,7 +23,7 @@ import JuMP: _create_nlp_block_data, set_optimizer, GenericAffExpr, backend, ter
 import NLPModels: finalize, AbstractNLPModel, obj, grad!, cons!, jac_coord!, hess_coord!, hess_structure!, jac_structure!
 import SolverCore: GenericExecutionStats
 import MUMPS_seq_jll
-import CUDA: CUBLAS, CUSOLVER, CuVector, CuMatrix, has_cuda_gpu
+import CUDA: CUBLAS, CUSOLVER, CuVector, CuMatrix, has_cuda_gpu, R_64F
 
 const MOI = MathOptInterface
 const MOIU = MathOptInterface.Utilities


### PR DESCRIPTION
This PR is a follow-up of #35. With this change, LapackGPU now uses cuSOLVER's sytrs, instead of the LapackCPU's sytrs. 