### PR TITLE
MadNLPHSL build with MKL

### DIFF
--- a/lib/MadNLPHSL/Artifacts.toml
+++ b/lib/MadNLPHSL/Artifacts.toml
@@ -573,3 +573,52 @@ os = "windows"
     [[OpenBLAS32.download]]
     sha256 = "499fd4686fcf399113eadc4a6e23149147952a4a13fa57231ab72d4c73b1acb6"
     url = "https://github.com/JuliaBinaryWrappers/OpenBLAS32_jll.jl/releases/download/OpenBLAS32-v0.3.13+4/OpenBLAS32.v0.3.13.x86_64-w64-mingw32-libgfortran5.tar.gz"
+
+# MKL
+[[MKL]]
+arch = "i686"
+git-tree-sha1 = "51c68267c3ef9625c44f086a8211376f9e10aaff"
+lazy = true
+os = "windows"
+
+    [[MKL.download]]
+    sha256 = "693a00fe1c2fef57891617b023bcbe2e40955ca55df930e0b6be5435c26f04fa"
+    url = "https://github.com/JuliaBinaryWrappers/MKL_jll.jl/releases/download/MKL-v2021.1.1+1/MKL.v2021.1.1.i686-w64-mingw32.tar.gz"
+[[MKL]]
+arch = "x86_64"
+git-tree-sha1 = "073ff95e2c63501547247d6e1321bf4ee2a78933"
+lazy = true
+os = "macos"
+
+    [[MKL.download]]
+    sha256 = "b7a5dd32e4a005a752bc4c3e6d425bf3b5bb1861730bbc4214216aa2c520f42d"
+    url = "https://github.com/JuliaBinaryWrappers/MKL_jll.jl/releases/download/MKL-v2021.1.1+1/MKL.v2021.1.1.x86_64-apple-darwin.tar.gz"
+[[MKL]]
+arch = "x86_64"
+git-tree-sha1 = "b30e86ec62f2d592fcea7086c63f61ebecd6f83e"
+lazy = true
+os = "windows"
+
+    [[MKL.download]]
+    sha256 = "56e783ad5f4f96ce6545b870ad80c4d6865129a59d6f7b317c6b14bda9d157ad"
+    url = "https://github.com/JuliaBinaryWrappers/MKL_jll.jl/releases/download/MKL-v2021.1.1+1/MKL.v2021.1.1.x86_64-w64-mingw32.tar.gz"
+[[MKL]]
+arch = "i686"
+git-tree-sha1 = "7f8c7caca0280096e7c4348da12931ae0c8a7dce"
+lazy = true
+libc = "glibc"
+os = "linux"
+
+    [[MKL.download]]
+    sha256 = "3280ae5ce7209f184b4d948b85dcb86f0cd124385d92d8ccbaa640b42d92b158"
+    url = "https://github.com/JuliaBinaryWrappers/MKL_jll.jl/releases/download/MKL-v2021.1.1+1/MKL.v2021.1.1.i686-linux-gnu.tar.gz"
+[[MKL]]
+arch = "x86_64"
+git-tree-sha1 = "a8e009985328801a84c9af6610f94f77a7c12852"
+lazy = true
+libc = "glibc"
+os = "linux"
+
+    [[MKL.download]]
+    sha256 = "70800f6e75e8ac3a0ff66069bec20ef410e9b240ef4a0f3b96cbbab3df81700f"
+    url = "https://github.com/JuliaBinaryWrappers/MKL_jll.jl/releases/download/MKL-v2021.1.1+1/MKL.v2021.1.1.x86_64-linux-gnu.tar.gz" 

--- a/lib/MadNLPHSL/README.md
+++ b/lib/MadNLPHSL/README.md
@@ -10,6 +10,8 @@ To build MadNLP with HSL linear solvers (Ma27, Ma57, Ma77, Ma86, Ma97), the sour
 # either one of the following should be given
 julia> ENV["MADNLP_HSL_SOURCE_PATH"] = "/opt/coinhsl" 
 julia> ENV["MADNLP_HSL_LIBRARY_PATH"] = "/usr/lib/libcoinhsl.so"
+# optionally, one can specify
+julia> ENV["MADNLP_HSL_BLAS"] = "openblas" # default is "mkl"
 ```
 After obtaining the source code or the libarary, run
 ```julia

--- a/lib/MadNLPHSL/deps/build.jl
+++ b/lib/MadNLPHSL/deps/build.jl
@@ -3,6 +3,12 @@
 
 using Pkg.Artifacts, BinaryProvider
 
+ if haskey(ENV,"MADNLP_HSL_BLAS")
+    blasvendor = (ENV["MADNLP_HSL_BLAS"]=="openblas") ? :openblas : :mkl
+else
+    blasvendor =  artifact_hash("MKL",joinpath(@__DIR__, "..", "Artifacts.toml")) != nothing ? :mkl : :openblas
+ end
+
 const verbose = "--verbose" in ARGS
 const prefix = Prefix(@__DIR__)
 const so = BinaryProvider.platform_dlext()
@@ -16,8 +22,9 @@ const hsl_version = haskey(ENV,"MADNLP_HSL_VERSION_NUMBER") ? ENV["MADNLP_HSL_VE
 const FC = haskey(ENV,"MADNLP_FC") ? ENV["MADNLP_FC"] : `gfortran`
 const libmetis_dir = joinpath(artifact"METIS", "lib")
 const with_metis = `-L$libmetis_dir $rpath$libmetis_dir -lmetis`
-const libopenblas_dir = joinpath(artifact"OpenBLAS32","lib")
-const with_openblas = `-L$libopenblas_dir $rpath$libopenblas_dir -lopenblas`
+const libblas_dir = joinpath(blasvendor == :mkl ? artifact"MKL" : artifact"OpenBLAS32","lib")
+const with_blas = blasvendor == :mkl ? `-L$libblas_dir $rpath$libblas_dir -lmkl_rt` :
+    `-L$libblas_dir $rpath$libblas_dir -lopenblas`
 const installer = Sys.isapple() ? "brew install" : Sys.iswindows() ? "pacman -S" : "sudo apt install"
 
 rm(libdir;recursive=true,force=true)
@@ -45,7 +52,7 @@ if hsl_source_path != ""
         push!(OC,OutputCollector(`$FC -fopenmp -fPIC -c -O3 -o hsl_mc68/C/hsl_mc68i_ciface.o hsl_mc68/C/hsl_mc68i_ciface.f90`,verbose=verbose))
         push!(OC,OutputCollector(`$FC -fopenmp -fPIC -c -O3 -o hsl_ma97/C/hsl_ma97d_ciface.o hsl_ma97/C/hsl_ma97d_ciface.f90`,verbose=verbose))
         wait.(OC); empty!(OC)
-        wait(OutputCollector(`$FC -o$(libdir)/libhsl.$so -shared -fPIC -O3 common/deps90.o common/deps.o mc19/mc19d.o ma27/ma27d.o ma57/ma57d.o hsl_ma77/hsl_ma77d.o hsl_ma77/C/hsl_ma77d_ciface.o hsl_ma86/hsl_ma86d.o hsl_ma86/C/hsl_ma86d_ciface.o hsl_mc68/C/hsl_mc68i_ciface.o hsl_ma97/hsl_ma97d.o hsl_ma97/C/hsl_ma97d_ciface.o -fopenmp $with_metis $with_openblas`,verbose=verbose))
+        wait(OutputCollector(`$FC -o$(libdir)/libhsl.$so -shared -fPIC -O3 common/deps90.o common/deps.o mc19/mc19d.o ma27/ma27d.o ma57/ma57d.o hsl_ma77/hsl_ma77d.o hsl_ma77/C/hsl_ma77d_ciface.o hsl_ma86/hsl_ma86d.o hsl_ma86/C/hsl_ma86d_ciface.o hsl_mc68/C/hsl_mc68i_ciface.o hsl_ma97/hsl_ma97d.o hsl_ma97/C/hsl_ma97d_ciface.o -fopenmp $with_metis $with_blas`,verbose=verbose))
         cd("$(@__DIR__)")
         product = FileProduct(prefix,joinpath(libdir,"libhsl.$so"), :libhsl)
     end


### PR DESCRIPTION
This change allows building MadNLPHSL with MKL.

The reason for switching from always using OpenBLAS is that it appears that for some reason OpenBLAS (provided via the artifacts of OpenBLAS32_jll) doesn't work well with julia's multithreading (it appears that it doesn't run in parallel). It works well with MKL on the other hand. 

Now we use MKL by default and use OpenBLAS only when the user specifies to do so, or a compatible artifact is not available.