### PR TITLE
Use LapackCPU in MINLPTests

### DIFF
--- a/test/minlp_test.jl
+++ b/test/minlp_test.jl
@@ -1,4 +1,7 @@
-const OPTIMIZER = ()->MadNLP.Optimizer(print_level=MadNLP.ERROR)
+const OPTIMIZER = ()->MadNLP.Optimizer(
+    linear_solver=MadNLPLapackCPU,
+    print_level=MadNLP.ERROR
+)
 
 @testset "MINLPTests" begin
     ###
@@ -10,8 +13,6 @@ const OPTIMIZER = ()->MadNLP.Optimizer(print_level=MadNLP.ERROR)
         exclude = [
             "005_011",  # Uses the function `\`
             "006_010",  # User-defined function without Hessian (autodiff only provides 1st order)
-            "004_010", # Umfpack not passing the test; might be converging to a different solution?
-            "004_011", # Umfpack not passing the test; might be converging to a different solution?
         ],
         objective_tol = 1e-5,
         primal_tol = 1e-5,
@@ -26,3 +27,4 @@ const OPTIMIZER = ()->MadNLP.Optimizer(print_level=MadNLP.ERROR)
         OPTIMIZER,
     )
 end
+


### PR DESCRIPTION
`MINLPTests.jl` have some nonconvex NLPs, and there have been issue of Umfpack converging to a different local solution. This is OK, but this makes the test fail in some instances. This is probably because Umfpack uses the inertia-free method and different regularization method alters the path of iterates. Now we use MadNLPLapackCPU (which reveals inertia) to avoid this behavior.