### PR TITLE
Add decode option in benchmark

### DIFF
--- a/benchmark/benchmark-power.jl
+++ b/benchmark/benchmark-power.jl
@@ -18,7 +18,9 @@ include("config.jl")
         pm = instantiate_model(joinpath(PGLIB_PATH,case),type,PowerModels.build_opf)
         println("Solving $(get_name(pm))")
         gcoff && GC.enable(false);
-        return solver(pm)
+        retval = solver(pm)
+        gcoff && GC.enable(true);
+        return retval
     end
 
     function get_status(code::MOI.TerminationStatusCode)

--- a/benchmark/config.jl
+++ b/benchmark/config.jl
@@ -5,6 +5,7 @@ const SOLVER = ARGS[2]
 const VERBOSE = ARGS[3] == "true"
 const QUICK = ARGS[4] == "true"
 const GCOFF = ARGS[5] == "true"
+const DECODE = ARGS[6] == "true"
 
 addprocs(parse(Int,NP),exeflags="--project=.")
 Pkg.instantiate()

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -28,6 +28,9 @@ function parse_commandline()
         "--quick", "-q"
             help = "run tests with reduced number of instances"
             action = :store_true
+        "--decode", "-d"
+            help = "decode the cutest instances"
+            action = :store_true
         "testsets"
             help = "testsets for benchmark (separated by comma). possible values: cutest, power"
             required = true
@@ -60,7 +63,7 @@ function main()
     for class in CLASSES
         for solver in SOLVERS
             launch_script = joinpath(PROJECT_PATH, "benchmark-$class.jl")
-            run(`julia --project=$PROJECT_PATH $launch_script $(pargs["nprocs"]) $solver $(pargs["verbose"]) $(pargs["quick"]) $(pargs["gcoff"])`)
+            run(`julia --project=$PROJECT_PATH $launch_script $(pargs["nprocs"]) $solver $(pargs["verbose"]) $(pargs["quick"]) $(pargs["gcoff"]) $(pargs["decode"])`)
         end
     end
 


### PR DESCRIPTION
This PR adds decode option for running cutest benchmark. By default, decoding the problem is skipped, and it is only run when the decode option is used